### PR TITLE
Dynamic width containers

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -74,10 +74,10 @@
 	
 	$(window).resize(function() {
 	
-	  var newWidth = $fluidEl.width();
 	  $allVideos.each(function() {
 	  
 	    var $el = $(this);
+        var newWidth = $el.parent().width();
 	    $el
 	        .width(newWidth)
 	        .height(newWidth * $el.attr('data-aspectRatio'));

--- a/demo.html
+++ b/demo.html
@@ -73,11 +73,11 @@
 	});
 	
 	$(window).resize(function() {
-	
+	   
 	  $allVideos.each(function() {
 	  
 	    var $el = $(this);
-        var newWidth = $el.parent().width();
+        var newWidth = $el.parents('figure').width();
 	    $el
 	        .width(newWidth)
 	        .height(newWidth * $el.attr('data-aspectRatio'));


### PR DESCRIPTION
Previously, the example did not handle multiple containers on the same page if they were not all the same width. With this change. the width of the iframe, and subsequently its height, get set based on the width of the iframe's immediate parent. 

For example, if the first figure has a width of 150px, each video receives a width of 150px instead of filling their own container figure elements:

![screen shot 2017-03-03 at 3 57 35 pm](https://cloud.githubusercontent.com/assets/755353/23568804/4822f91a-002a-11e7-9e82-25dcf39ea667.png)
<img width="816" alt="screen shot 2017-03-03 at 3 57 26 pm" src="https://cloud.githubusercontent.com/assets/755353/23568810/4f71d182-002a-11e7-9239-172ec9c421d7.png">
